### PR TITLE
Add CHANGELOG and make ready for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] - 2019-05-13
+### Added
+- Initial `cloud-finder` implementation.

--- a/Makefile
+++ b/Makefile
@@ -4,3 +4,6 @@ test:
 
 docker-image:
 	docker build -t cloud-finder .
+
+clean:
+	rm -rf coverage.txt


### PR DESCRIPTION
We will shortly be making improvements that warrant a 1.0 upgrade for better usage as a library. To that end, we will cut a tag for 0.1.0 before making those possibly breaking changes.