### PR TITLE
Export AWS_DOMAIN

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: go
 go:
   - 1.11.x
   - 1.12.x
+  - 1.13.x
   - tip
 
 env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2019-11-08
+### Added
+- Export the AWS region domain as `AWS_DOMAIN`.
+
 ## [0.1.0] - 2019-05-13
 ### Added
 - Initial `cloud-finder` implementation.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/C2FO/cloud-finder.svg?branch=master)](https://travis-ci.org/C2FO/cloud-finder) [![codecov](https://codecov.io/gh/c2fo/cloud-finder/branch/master/graph/badge.svg)](https://codecov.io/gh/c2fo/cloud-finder)
 
 This project should serve as a way to help processes discover which cloud,
-region, endpoint, etc. they need for dynamic configuration. 
+region, endpoint, etc. they need for dynamic configuration.
 
 <!-- TOC depthFrom:1 depthTo:6 withLinks:1 updateOnSave:1 orderedList:0 -->
 
@@ -63,6 +63,7 @@ AWS_AVAILABILITY_ZONE=us-west-2c
 AWS_AMI_ID=ami-edfc2abd
 AWS_HOSTNAME=ip-1-1-1-1
 AWS_INSTANCE_ID=i-8af98240
+AWS_DOMAIN=amazonaws.com
 ```
 
 ### GCP

--- a/pkg/providers/aws/provider.go
+++ b/pkg/providers/aws/provider.go
@@ -43,6 +43,7 @@ func (p *Provider) Check(opts *provider.Options) provider.Result {
 		"AWS_LOCAL_IPV4":        "/latest/meta-data/local-ipv4",
 		"AWS_MAC":               "/latest/meta-data/mac",
 		"AWS_AVAILABILITY_ZONE": "/latest/meta-data/placement/availability-zone",
+		"AWS_DOMAIN":            "/latest/meta-data/services/domain",
 	}
 
 	responses, err := client.GetAll(requests)

--- a/pkg/providers/aws/provider_test.go
+++ b/pkg/providers/aws/provider_test.go
@@ -22,6 +22,7 @@ func TestRegion(t *testing.T) {
 	assert.Equal(t, "", region("us-west"))
 	assert.Equal(t, "ap-south-1", region("ap-south-1a"))
 	assert.Equal(t, "us-gov-west-1", region("us-gov-west-1"))
+	assert.Equal(t, "cn-north-1", region("cn-north-1a"))
 }
 
 func TestAWSProviderImplementsProvider(t *testing.T) {
@@ -44,6 +45,7 @@ func withTestRoutes(t *testing.T, f func(t *testing.T)) {
 	registerHTTPMockResponse("GET", "/latest/meta-data/local-ipv4", `10.0.1.181`)
 	registerHTTPMockResponse("GET", "/latest/meta-data/mac", `0a:2e:31:ec:fa:45`)
 	registerHTTPMockResponse("GET", "/latest/meta-data/placement/availability-zone", `us-west-2c`)
+	registerHTTPMockResponse("GET", "/latest/meta-data/services/domain", `amazonaws.com`)
 
 	f(t)
 }
@@ -75,5 +77,6 @@ func TestAWSProvider(t *testing.T) {
 
 		assert.Equal(t, "us-west-2c", awsResult.AvailabilityZone())
 		assert.Equal(t, "us-west-2", awsResult.Region())
+		assert.Equal(t, "amazonaws.com", awsResult.Domain())
 	})
 }

--- a/pkg/providers/aws/result.go
+++ b/pkg/providers/aws/result.go
@@ -86,3 +86,8 @@ func (r Result) AvailabilityZone() string {
 func (r Result) Region() string {
 	return r.responses["AWS_REGION"]
 }
+
+// Domain returns the AWS domain of the region.
+func (r Result) Domain() string {
+	return r.responses["AWS_DOMAIN"]
+}


### PR DESCRIPTION
Export the AWS domain of the current region. One thing this can help with is to dynamically generate S3 endpoints in apps.